### PR TITLE
Use timestamp to determine time intervals

### DIFF
--- a/CpuLoad/cpuload.h
+++ b/CpuLoad/cpuload.h
@@ -51,8 +51,8 @@ struct cpuload_s
 	u64_t t_window;					/* Length of a window, in ticks. = t_interval * CL_N_INTERVAL */
 	u64_t t_interval;				/* Length of an interval, in ticks */
 	u64_t t_threshold;				/* Boundary value for decision: busy or idle */
+	u64_t t_next;					/* Start of next interval */
 
-	u64_t t_used;					/* Amount of current interval accounted for. */
 	u64_t t_busy;					/* Amount of current interval that was busy */
 	u32_t rolling[CL_N_INTERVALS];	/* Percent busy in each interval */
 	u32_t rolling_sum;				/* Sum of the rolling array */


### PR DESCRIPTION
Instead of using the sum of accounted busy and idle time to see if an
interval elapsed, determine the start of the next interval in advance
and use the current timestamp.

This way, we only need to keep track of "busy" time.

Well, as with the other PR, just playing around... at first I thought that this would lead to more "stable" time intervals, then I noticed it's basically the same calculation, but done differently. Well.

To make things worse, this PR is more or less mutually exclusive with PR #1 .