### PR TITLE
Add C continuous integration

### DIFF
--- a/.github/workflows/c-ci.yml
+++ b/.github/workflows/c-ci.yml
@@ -1,0 +1,19 @@
+name: C CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make -C CpuLoad
+    - name: make test
+      run: make -C CpuLoad test


### PR DESCRIPTION
Did you know that you can click a few buttons and get a docker building your tests somewhere in Microsoft's github cloud for free[tm]?

CI won't succeed until merging PR #4, though ;-)